### PR TITLE
Fix package

### DIFF
--- a/emit.el
+++ b/emit.el
@@ -103,11 +103,11 @@
 
 ;; prefix-selector
 
-(defun emit-interpret-prefix-as-number (prefix-arg)
+(defun emit-interpret-prefix-as-number (prefix)
   (cond
-   ((numberp prefix-arg) prefix-arg)
-   ((and (-non-nil prefix-arg) (listp prefix-arg))
-    (truncate (log (car prefix-arg) 4)))
+   ((numberp prefix) prefix)
+   ((and (-non-nil prefix) (listp prefix))
+    (truncate (log (car prefix) 4)))
    (0)))
 
 (defmacro emit-prefix-selector-fn (&rest functions)

--- a/emit.el
+++ b/emit.el
@@ -30,7 +30,8 @@
 
 ;; named-builder
 
-(defvar emit-named-builder-suffix "-fn")
+(eval-and-compile
+  (defvar emit-named-builder-suffix "-fn"))
 
 (defmacro emit-named-build (name builder &rest args)
   "Alias NAME to the function produced by applying BUILDER to ARGS."

--- a/emit.el
+++ b/emit.el
@@ -6,7 +6,7 @@
 ;; Keywords: init utility general library
 ;; URL: https://github.com/IvanMalison/emit
 ;; Version: 0.0.0
-;; Package-Requires: ((dash "2.10.0") (emacs "24"))
+;; Package-Requires: ((dash "2.10.0") (emacs "24") (cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -27,6 +27,9 @@
 ;; configuring Emacs.
 
 ;;; Code:
+
+(require 'dash)
+(require 'cl-lib)
 
 ;; named-builder
 
@@ -113,7 +116,7 @@
          (conditions
           (cl-loop for fn in functions
                    collect (list selector-number fn)
-                   do (incf selector-number))))
+                   do (cl-incf selector-number))))
     `(lambda (arg)
        ,(format "Call one of %s depending the prefix argument.\nCall `%s' by default."
                 (mapconcat (lambda (fn-or-symbol)


### PR DESCRIPTION
- Fix byte-compile error. Declare variable which uses in macro at compile time
- Load libraries explicitly and add cl-lib dependency
- Rename local variable whose name is same as global variable for byte-compile warning
